### PR TITLE
feat: log fatal errors, get correct caller. closes #1, fixes #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.vs
+.vscode
+.idea
+.cache
+bin
+logs
+vendor
+.DS_Store
+desktop.ini
+*.log
+*.exe

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,26 @@
-The MIT License (MIT)
-Copyright (c) 2019 Vincent Paul Fiestada
+Copyright 2019 Vincent Paul Fiestada
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![GoReportCard](https://goreportcard.com/badge/github.com/vincentfiestada/captainslog)](https://goreportcard.com/report/github.com/vincentfiestada/captainslog)
 [![GoDoc](https://godoc.org/github.com/vincentfiestada/captainslog?status.svg)](https://godoc.org/github.com/vincentfiestada/captainslog)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-00b6ff.svg?labelColor=1F6CB4)](https://conventionalcommits.org)
-[![License: MIT](https://img.shields.io/github/license/vincentfiestada/acrylic.svg?labelColor=1F6CB4&color=00b6ff)](https://github.com/vincentfiestada/acrylic/blob/master/LICENSE)
+[![License: BSD-3](https://img.shields.io/github/license/vincentfiestada/acrylic.svg?labelColor=1F6CB4&color=00b6ff)](https://github.com/vincentfiestada/acrylic/blob/master/LICENSE)
 
 A simple logging library for [Go](https://golang.org/).
 
 - Support for multiple logging levels
 - Colored output, even on Windows
-- Output name of calling function
+- Print the calling function name
 
 ![Screenshot of captainslog in action](./assets/screenshot.png)
 
@@ -18,13 +18,30 @@ A simple logging library for [Go](https://golang.org/).
 ```go
 package main
 
-import log "github.com/vincentfiestada/captainslog"
+import (
+	"math"
+
+	"github.com/vincentfiestada/captainslog"
+)
+
+var log *captainslog.Logger
 
 func main() {
-	log.SetLevel(log.LogLevelSilly)
-
-	log.Info("Info %d", 1)
+	log.Info("π = %v", math.Pi)
 }
+
+func init() {
+	log = captainslog.NewLogger()
+}
+
+```
+
+## Development
+
+Run tests recursively with coverage:
+
+```
+go test ./... --cover
 ```
 
 <small>Gopher artwork by [Ashley McNamara](https://twitter.com/ashleymcnamara) on [Gopherize.me](https://gopherize.me/gopher/5dcbe4dc48ab6fbf903aae352f8742cb59e7099b)</small>

--- a/caller/caller.go
+++ b/caller/caller.go
@@ -8,15 +8,19 @@ import (
 const anonymous = "anonymous"
 
 // GetName returns the name of the n-th caller up the stack
-func GetName(n int) string {
-	callerPtrs := make([]uintptr, 1)
-	callersCount := runtime.Callers(n, callerPtrs)
-	if callersCount == 0 {
-		return anonymous
+func GetName(skip int) string {
+	callers := make([]uintptr, skip+3)
+	n := runtime.Callers(0, callers)
+	target := runtime.Frame{
+		Function: anonymous,
 	}
-	callerFunc := runtime.FuncForPC(callerPtrs[0])
-	if callerFunc == nil {
-		return anonymous
+	if n > 0 {
+		frames := runtime.CallersFrames(callers)
+		index := 0
+		for current, more := frames.Next(); more && index < n+skip; current, more = frames.Next() {
+			target = current
+			index++
+		}
 	}
-	return callerFunc.Name()
+	return target.Function
 }

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -1,0 +1,18 @@
+package caller_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vincentfiestada/captainslog/caller"
+)
+
+func TestGetName(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := "github.com/vincentfiestada/captainslog/caller_test.TestGetName"
+	assert.Equal(expected, caller.GetName(1))
+	func() {
+		assert.Equal(expected, caller.GetName(2))
+	}()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/vincentfiestada/captainslog v0.0.0-20180811073819-98f84a715826 h1:YRwIRkRphC8+5xKWgmMUiF/8nAQMPzQDsJm322HorNU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package captainslog
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/vincentfiestada/captainslog/caller"
@@ -17,8 +18,12 @@ const (
 	LogLevelInfo    = iota
 	LogLevelWarn    = iota
 	LogLevelError   = iota
+	LogLevelFatal   = iota
 	LogLevelQuiet   = iota
 )
+
+// Error codes
+const errFatal = 1
 
 // color print functions
 var (
@@ -150,6 +155,25 @@ func (log *Logger) Warn(format string, args ...interface{}) {
 // Error logs messages with level Error
 func (log *Logger) Error(format string, args ...interface{}) {
 	log.Log(LogLevelError, format, args...)
+}
+
+// Exit logs an error and exits with an error code
+func (log *Logger) Exit(code int, format string, args ...interface{}) {
+	log.Log(LogLevelFatal, format, args...)
+	os.Exit(code)
+}
+
+// Fatal logs an error and exits with error code 1
+func (log *Logger) Fatal(format string, args ...interface{}) {
+	log.Log(LogLevelFatal, format, args...)
+	os.Exit(errFatal)
+}
+
+// Panic log an error and panics
+func (log *Logger) Panic(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	log.Log(LogLevelFatal, msg)
+	panic(msg)
 }
 
 // printf a simple colorless print function

--- a/log_test.go
+++ b/log_test.go
@@ -1,15 +1,30 @@
-package captainslog
+package captainslog_test
 
-import "testing"
+import (
+	"testing"
 
-func TestDemo(_ *testing.T) {
-	log := NewLogger()
-	log.SetLevel(LogLevelSilly)
+	"github.com/vincentfiestada/captainslog"
+)
 
-	log.Silly("Test %d", 1)
-	log.Debug("Test %d", 2)
-	log.Verbose("Test %d", 3)
-	log.Info("Test %d", 4)
-	log.Warn("Test %d", 5)
-	log.Error("Test %d", 6)
+func TestDemo(t *testing.T) {
+	log := captainslog.NewLogger()
+	log.SetLevel(captainslog.LogLevelSilly)
+
+	log.Silly("%s", "silly")
+	log.Debug("%s", "debug")
+	log.Verbose("%s", "verbose")
+	log.Info("%s", "info")
+	log.Warn("%s", "warn")
+	log.Error("%s", "error")
+}
+
+func TestPanic(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fail()
+		}
+	}()
+
+	log := captainslog.NewLogger()
+	log.Panic("%s", "panic")
 }


### PR DESCRIPTION
## Changes

- log fatal errors using `log.Exit`, `log.Fatal`, and `log.Panic`
- get correct caller name with `caller.GetName`
- add tests for `caller.GetName`