### PR TITLE
Easily add multiple fields

### DIFF
--- a/demo/demo.go
+++ b/demo/demo.go
@@ -20,10 +20,29 @@ func main() {
 	log.Warn("%d", 4)
 	log.Error("%d", 5)
 
-	log.Field("captain", "picard").Trace("starship enterprise")
-	log.Field("captain", "picard").Debug("starship enterprise")
-	log.Field("captain", "picard").Info("starship enterprise")
-	log.Field("captain", "picard").Warn("starship enterprise")
-	log.Field("captain", "picard").Error("starship enterprise")
+	log.Fields(
+		log.I("captain", "picard"),
+	).Trace("starship enterprise")
+
+	log.Fields(
+		log.I("captain", "picard"),
+	).Debug("starship enterprise")
+
+	log.Fields(
+		log.I("captain", "picard"),
+	).Info("starship enterprise")
+
+	log.Fields(
+		log.I("captain", "picard"),
+	).Warn("starship enterprise")
+
+	log.Fields(
+		log.I("captain", "picard"),
+	).Error("starship enterprise")
+
+	log.Fields(
+		log.I("captain", "picard"),
+		log.I("first officer", "riker"),
+	).Info("starship enterprise")
 
 }

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -20,29 +20,19 @@ func main() {
 	log.Warn("%d", 4)
 	log.Error("%d", 5)
 
-	log.Fields(
-		log.I("captain", "picard"),
-	).Trace("starship enterprise")
-
-	log.Fields(
-		log.I("captain", "picard"),
-	).Debug("starship enterprise")
-
-	log.Fields(
-		log.I("captain", "picard"),
-	).Info("starship enterprise")
-
-	log.Fields(
-		log.I("captain", "picard"),
-	).Warn("starship enterprise")
-
-	log.Fields(
-		log.I("captain", "picard"),
-	).Error("starship enterprise")
+	log.Field("captain", "picard").Trace("starship enterprise")
+	log.Field("captain", "picard").Debug("starship enterprise")
+	log.Field("captain", "picard").Info("starship enterprise")
+	log.Field("captain", "picard").Warn("starship enterprise")
+	log.Field("captain", "picard").Error("starship enterprise")
 
 	log.Fields(
 		log.I("captain", "picard"),
 		log.I("first officer", "riker"),
+		log.I("science officer", "data"),
+		log.I("medical officer", "crusher"),
+		log.I("chief engineer", "la forge"),
+		log.I("security officer", "worf"),
 	).Info("starship enterprise")
 
 }

--- a/format/flat.go
+++ b/format/flat.go
@@ -19,13 +19,13 @@ func Flat(msg *msg.Message) {
 	write(stream, msg.Time)
 	separate(stream)
 	write(stream, colorize(msg.Name))
-	if len(msg.Fields) > 0 {
+	if len(msg.Data) > 0 {
 		separate(stream)
-		for i := 0; i < len(msg.Fields)-1; i += 2 {
+		for i := 0; i < len(msg.Data)-1; i += 2 {
 			if i > 0 {
 				write(stream, ", ")
 			}
-			write(stream, fmt.Sprintf("%s=%#v", msg.Fields[i], msg.Fields[i+1]))
+			write(stream, fmt.Sprintf("%s=%#v", msg.Data[i], msg.Data[i+1]))
 		}
 	}
 	separate(stream)

--- a/format/flat_test.go
+++ b/format/flat_test.go
@@ -22,7 +22,7 @@ func TestFlat(test *testing.T) {
 			Threshold: levels.Info,
 			Stdout:    stdout,
 			Format:    format.Flat,
-			Fields: []interface{}{
+			Data: []interface{}{
 				"captain",
 				"picard",
 				"first officer",

--- a/log.go
+++ b/log.go
@@ -71,7 +71,12 @@ func (log *Logger) I(name string, value interface{}) msg.Field {
 	return msg.Field{name, value}
 }
 
-// Fields adds multiple fields to the log
+// Field creates a message with a data field
+func (log *Logger) Field(name string, value interface{}) *msg.Message {
+	return log.message().Field(name, value)
+}
+
+// Fields creates a message with multiple data fields
 func (log *Logger) Fields(fields ...msg.Field) *msg.Message {
 	return log.message().Fields(fields...)
 }

--- a/log.go
+++ b/log.go
@@ -62,13 +62,18 @@ func (log *Logger) message() *msg.Message {
 		HasColor:  log.HasColor,
 		Threshold: log.Level,
 		Format:    log.format,
-		Fields:    []interface{}{},
+		Data:      []interface{}{},
 	}
 }
 
-// Field adds a data field to the log
-func (log *Logger) Field(name string, value interface{}) *msg.Message {
-	return log.message().Field(name, value)
+// I returns a key-value pair
+func (log *Logger) I(name string, value interface{}) msg.Field {
+	return msg.Field{name, value}
+}
+
+// Fields adds multiple fields to the log
+func (log *Logger) Fields(fields ...msg.Field) *msg.Message {
+	return log.message().Fields(fields...)
 }
 
 // Trace logs a message with level Trace

--- a/log_test.go
+++ b/log_test.go
@@ -160,7 +160,9 @@ func TestFields(test *testing.T) {
 		log.Stdout = stdout
 		log.Stderr = stderr
 
-		log.Field("captain", "picard").Info("energize")
+		log.Fields(
+			log.I("captain", "picard"),
+		).Info("energize")
 	})
 
 	logs[0].Message.Equals("energize")

--- a/log_test.go
+++ b/log_test.go
@@ -152,6 +152,21 @@ func TestPanic(test *testing.T) {
 	logs[0].Level.Equals("fatal")
 }
 
+func TestField(test *testing.T) {
+	t := preflight.Unit(test)
+
+	logs, _ := t.CaptureLogs(func(stdout *os.File, stderr *os.File) {
+		log := getLogger()
+		log.Stdout = stdout
+		log.Stderr = stderr
+
+		log.Field("captain", "picard").Info("energize")
+	})
+
+	logs[0].Message.Equals("energize")
+	logs[0].Fields.Equals("captain=\"picard\"")
+}
+
 func TestFields(test *testing.T) {
 	t := preflight.Unit(test)
 

--- a/msg/colors.go
+++ b/msg/colors.go
@@ -9,7 +9,7 @@ type Color func(string, ...interface{}) string
 
 // Color print functions
 var (
-	purple = color.New(color.FgMagenta).SprintfFunc()
+	cyan   = color.New(color.FgCyan).SprintfFunc()
 	blue   = color.New(color.FgBlue).SprintfFunc()
 	green  = color.New(color.FgGreen).SprintfFunc()
 	yellow = color.New(color.FgYellow).SprintfFunc()

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -43,7 +43,13 @@ func (msg *Message) Props() (stream *os.File, level string, color Color) {
 	}
 }
 
-// Fields adds multiple fields to the log
+// Field adds a data field to the message
+func (msg *Message) Field(name string, value interface{}) *Message {
+	msg.Data = append(msg.Data, name, value)
+	return msg
+}
+
+// Fields adds multiple fields to the message
 func (msg *Message) Fields(fields ...Field) *Message {
 	for _, field := range fields {
 		msg.Data = append(msg.Data, field[0], field[1])

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -8,6 +8,9 @@ import (
 	"github.com/vincentfiestada/captainslog/preflight"
 )
 
+// Field is a key-value pair
+type Field [2]interface{}
+
 // Message is a log message that gets built in multiple steps
 type Message struct {
 	Time      string
@@ -19,14 +22,14 @@ type Message struct {
 	Stdout    *os.File
 	Stderr    *os.File
 	Format    Printer
-	Fields    []interface{}
+	Data      []interface{}
 }
 
 // Props returns the message stream, level, and color
 func (msg *Message) Props() (stream *os.File, level string, color Color) {
 	switch msg.Level {
 	case levels.Trace:
-		return msg.Stdout, "trace", purple
+		return msg.Stdout, "trace", cyan
 	case levels.Debug:
 		return msg.Stdout, "debug", green
 	case levels.Info:
@@ -40,9 +43,11 @@ func (msg *Message) Props() (stream *os.File, level string, color Color) {
 	}
 }
 
-// Field adds a data field to the log
-func (msg *Message) Field(name string, value interface{}) *Message {
-	msg.Fields = append(msg.Fields, name, value)
+// Fields adds multiple fields to the log
+func (msg *Message) Fields(fields ...Field) *Message {
+	for _, field := range fields {
+		msg.Data = append(msg.Data, field[0], field[1])
+	}
 	return msg
 }
 

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -83,11 +83,19 @@ func TestPanic(test *testing.T) {
 	message.Panic("x")
 }
 
+func TestField(test *testing.T) {
+	t := preflight.Unit(test)
+
+	message := createMessage(levels.Info)
+	message.Field("science officer", "data")
+
+	t.Expect(message.Data).HasLength(2)
+}
+
 func TestFields(test *testing.T) {
 	t := preflight.Unit(test)
 
 	message := createMessage(levels.Info)
-
 	message.Fields(
 		msg.Field{"science officer", "data"},
 		msg.Field{"chief engineer", "geordi la forge"},

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -42,7 +42,7 @@ func TestLogs(test *testing.T) {
 
 	message.Format = func(input *msg.Message) {
 		t.Expect(input).Equals(message)
-		t.Expect(input.Fields).HasLength(0)
+		t.Expect(input.Data).HasLength(0)
 	}
 
 	message.Trace("captainslog")
@@ -88,10 +88,12 @@ func TestFields(test *testing.T) {
 
 	message := createMessage(levels.Info)
 
-	message.Field("science officer", "data")
-	message.Field("chief engineer", "geordi la forge")
+	message.Fields(
+		msg.Field{"science officer", "data"},
+		msg.Field{"chief engineer", "geordi la forge"},
+	)
 
-	t.Expect(message.Fields).HasLength(4)
+	t.Expect(message.Data).HasLength(4)
 }
 
 /**
@@ -106,6 +108,6 @@ func createMessage(level int) *msg.Message {
 		Stdout:    os.Stdout,
 		Stderr:    os.Stderr,
 		Format:    format.Flat,
-		Fields:    []interface{}{},
+		Data:      []interface{}{},
 	}
 }


### PR DESCRIPTION
Fields have been refactored to make setting multiple fields much easier, while still preserving order.

```go
log.Fields(
    log.I("captain", "picard"),
    log.I("first officer", "riker"),
).Info("starship enterprise")
```