### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library is designed to provide a familiar yet powerful interface for loggin
 package main
 
 import (
-	"github.com/vincentfiestada/captainslog"
+	"github.com/vincentfiestada/captainslog/v2"
 )
 
 var log = captainslog.NewLogger()
@@ -61,7 +61,7 @@ func main() {
 
 ## Performance
 
-The main goals of this library are convenience and familiarity for programmers. Certain design decisions have a negative impact on performance. Take this into consideration before choosing to use captainslog. You can run these benchmarks using `Invoke-Benchmarks`.
+The main goals of this library are convenience and familiarity for programmers. Certain design decisions have a negative impact on performance. Take this into consideration before choosing to use captainslog. To see for yourself, run the benchmarks using `Invoke-Benchmarks`.
 
 ## Development
 

--- a/benchmarks/benchmarks.go
+++ b/benchmarks/benchmarks.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vincentfiestada/captainslog"
-	"github.com/vincentfiestada/captainslog/format"
+	"github.com/vincentfiestada/captainslog/v2"
+	"github.com/vincentfiestada/captainslog/v2/format"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -3,15 +3,15 @@ package caller_test
 import (
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/caller"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2/caller"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 func TestGetName(test *testing.T) {
 	t := preflight.Unit(test)
 
 	// GetName(1) should return the name of the calling function
-	this := "github.com/vincentfiestada/captainslog/caller_test.TestGetName"
+	this := "github.com/vincentfiestada/captainslog/v2/caller_test.TestGetName"
 	t.Expect(caller.GetName(1)).Equals(this)
 
 	func() {

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/vincentfiestada/captainslog"
-	"github.com/vincentfiestada/captainslog/levels"
+	"github.com/vincentfiestada/captainslog/v2"
+	"github.com/vincentfiestada/captainslog/v2/levels"
 )
 
 var log *captainslog.Logger

--- a/doc.go
+++ b/doc.go
@@ -3,5 +3,5 @@ package captainslog
 
 // Package information
 const (
-	Version = "2.0.0"
+	Version = "2.1.0"
 )

--- a/format/flat.go
+++ b/format/flat.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vincentfiestada/captainslog/msg"
+	"github.com/vincentfiestada/captainslog/v2/msg"
 )
 
 // Flat formats a message as flat text

--- a/format/flat_test.go
+++ b/format/flat_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/format"
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/msg"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2/format"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/msg"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 func TestFlat(test *testing.T) {

--- a/format/json.go
+++ b/format/json.go
@@ -3,7 +3,7 @@ package format
 import (
 	"fmt"
 
-	"github.com/vincentfiestada/captainslog/msg"
+	"github.com/vincentfiestada/captainslog/v2/msg"
 )
 
 // JSON formats a message as JSON

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/format"
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/msg"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2/format"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/msg"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 func TestJSON(test *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vincentfiestada/captainslog
+module github.com/vincentfiestada/captainslog/v2
 
 go 1.12
 

--- a/log.go
+++ b/log.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/vincentfiestada/captainslog/caller"
-	"github.com/vincentfiestada/captainslog/format"
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/msg"
+	"github.com/vincentfiestada/captainslog/v2/caller"
+	"github.com/vincentfiestada/captainslog/v2/format"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/msg"
 )
 
 // Defaults

--- a/log_test.go
+++ b/log_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vincentfiestada/captainslog"
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 // Patterns

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 // Field is a key-value pair

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/format"
-	"github.com/vincentfiestada/captainslog/levels"
-	"github.com/vincentfiestada/captainslog/msg"
-	"github.com/vincentfiestada/captainslog/preflight"
+	"github.com/vincentfiestada/captainslog/v2/format"
+	"github.com/vincentfiestada/captainslog/v2/levels"
+	"github.com/vincentfiestada/captainslog/v2/msg"
+	"github.com/vincentfiestada/captainslog/v2/preflight"
 )
 
 func TestProps(test *testing.T) {


### PR DESCRIPTION
The previous v2 release did not follow all the [rules](https://github.com/golang/go/wiki/Modules) for module versioning. Starting now, the major version number should be used when importing the library. For example,

```
import "github.com/vincentfiestada/captainslog/v2"
```