### PR TITLE
refactor: rename module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Captain's Log
 
-[![](https://github.com/vincentfiestada/captainslog/workflows/Unit%20Tests/badge.svg)](https://github.com/vincentfiestada/captainslog/actions?query=workflow%3A%22Unit+Tests%22)
-[![](https://github.com/vincentfiestada/captainslog/workflows/Style%20Checks/badge.svg)](https://github.com/vincentfiestada/captainslog/actions?query=workflow%3A%22Style+Checks%22)
-[![Go Reference](https://img.shields.io/badge/reference-007d9c.svg?labelColor=16161b&logo=go&logoColor=white)](https://pkg.go.dev/github.com/vincentfiestada/captainslog/v2?tab=doc)
+[![](https://github.com/vncntx/captainslog/workflows/Unit%20Tests/badge.svg)](https://github.com/vncntx/captainslog/actions?query=workflow%3A%22Unit+Tests%22)
+[![](https://github.com/vncntx/captainslog/workflows/Style%20Checks/badge.svg)](https://github.com/vncntx/captainslog/actions?query=workflow%3A%22Style+Checks%22)
+[![Go Reference](https://img.shields.io/badge/reference-007d9c.svg?labelColor=16161b&logo=go&logoColor=white)](https://pkg.go.dev/github.com/vncntx/captainslog/v2?tab=doc)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-0047ab.svg?labelColor=16161b)](https://conventionalcommits.org)
 [![License: BSD-3](https://img.shields.io/github/license/vincentfiestada/captainslog.svg?labelColor=16161b&color=0047ab)](./license)
 
@@ -20,7 +20,7 @@ A simple logging library for [Go](https://golang.org/)
 ## Installation
 
 ```
-go get github.com/vincentfiestada/captainslog/v2
+go get github.com/vncntx/captainslog/v2
 ```
 
 ## Usage
@@ -31,7 +31,7 @@ This library is designed to provide a familiar yet powerful interface for loggin
 package main
 
 import (
-	"github.com/vincentfiestada/captainslog/v2"
+	"captainslog/v2"
 )
 
 var log = captainslog.NewLogger()

--- a/benchmarks/benchmarks.go
+++ b/benchmarks/benchmarks.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vincentfiestada/captainslog/v2"
-	"github.com/vincentfiestada/captainslog/v2/format"
+	"captainslog/v2"
+	"captainslog/v2/format"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/caller/caller_test.go
+++ b/caller/caller_test.go
@@ -3,15 +3,15 @@ package caller_test
 import (
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/v2/caller"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/caller"
+	"captainslog/v2/preflight"
 )
 
 func TestGetName(test *testing.T) {
 	t := preflight.Unit(test)
 
 	// GetName(1) should return the name of the calling function
-	this := "github.com/vincentfiestada/captainslog/v2/caller_test.TestGetName"
+	this := "captainslog/v2/caller_test.TestGetName"
 	t.Expect(caller.GetName(1)).Equals(this)
 
 	func() {
@@ -22,7 +22,7 @@ func TestGetName(test *testing.T) {
 func TestShorten(test *testing.T) {
 	t := preflight.Unit(test)
 
-	path := "github.com/vincentfiestada/captainslog/caller_test.TestShorten"
+	path := "captainslog/caller_test.TestShorten"
 
 	// should return the most specific path possible
 	t.Expect(caller.Shorten(path, 15)).Equals("TestShorten")

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/vincentfiestada/captainslog/v2"
-	"github.com/vincentfiestada/captainslog/v2/levels"
+	"captainslog/v2"
+	"captainslog/v2/levels"
 )
 
 var log *captainslog.Logger

--- a/doc.go
+++ b/doc.go
@@ -3,5 +3,5 @@ package captainslog
 
 // Package information
 const (
-	Version = "2.4.3"
+	Version = "2.5.0"
 )

--- a/format/flat.go
+++ b/format/flat.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vincentfiestada/captainslog/v2/msg"
+	"captainslog/v2/msg"
 )
 
 // Flat formats a message as flat text

--- a/format/flat_test.go
+++ b/format/flat_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/v2/format"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/msg"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/format"
+	"captainslog/v2/levels"
+	"captainslog/v2/msg"
+	"captainslog/v2/preflight"
 )
 
 func TestFlat(test *testing.T) {

--- a/format/json.go
+++ b/format/json.go
@@ -3,7 +3,7 @@ package format
 import (
 	"fmt"
 
-	"github.com/vincentfiestada/captainslog/v2/msg"
+	"captainslog/v2/msg"
 )
 
 // JSON formats a message as JSON

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/v2/format"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/msg"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/format"
+	"captainslog/v2/levels"
+	"captainslog/v2/msg"
+	"captainslog/v2/preflight"
 )
 
 func TestJSON(test *testing.T) {

--- a/format/minimal.go
+++ b/format/minimal.go
@@ -3,7 +3,7 @@ package format
 import (
 	"fmt"
 
-	"github.com/vincentfiestada/captainslog/v2/msg"
+	"captainslog/v2/msg"
 )
 
 // Minimal prints a minimal log with no timestamp or name

--- a/format/minimal_test.go
+++ b/format/minimal_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/v2/format"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/msg"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/format"
+	"captainslog/v2/levels"
+	"captainslog/v2/msg"
+	"captainslog/v2/preflight"
 )
 
 func TestMinimal(test *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vincentfiestada/captainslog/v2
+module captainslog/v2
 
 go 1.16
 

--- a/log.go
+++ b/log.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/vincentfiestada/captainslog/v2/caller"
-	"github.com/vincentfiestada/captainslog/v2/format"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/msg"
+	"captainslog/v2/caller"
+	"captainslog/v2/format"
+	"captainslog/v2/levels"
+	"captainslog/v2/msg"
 )
 
 // Defaults

--- a/log_test.go
+++ b/log_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vincentfiestada/captainslog/v2"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2"
+	"captainslog/v2/levels"
+	"captainslog/v2/preflight"
 )
 
 // Patterns

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/levels"
+	"captainslog/v2/preflight"
 )
 
 // Field is a key-value pair

--- a/msg/msg_test.go
+++ b/msg/msg_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentfiestada/captainslog/v2/format"
-	"github.com/vincentfiestada/captainslog/v2/levels"
-	"github.com/vincentfiestada/captainslog/v2/msg"
-	"github.com/vincentfiestada/captainslog/v2/preflight"
+	"captainslog/v2/format"
+	"captainslog/v2/levels"
+	"captainslog/v2/msg"
+	"captainslog/v2/preflight"
 )
 
 func TestProps(test *testing.T) {


### PR DESCRIPTION
The module has been transferred to [vncntx/captainslog](https://github.com/vncntx/captainslog) and renamed to **captainslog/v2** and bumped to v2.5.0