### PR TITLE
fix: go version in .mod file

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 package captainslog
 
 const (
-	Version = "2.5.2"
+	Version = "2.5.3"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module vincent.click/pkg/captainslog/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/fatih/color v1.12.0
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	golang.org/x/sys v0.0.0-20210902050250-f475640dd07b // indirect
 )
+
+require github.com/mattn/go-colorable v0.1.8 // indirect


### PR DESCRIPTION
- fix: go version in `go.mod` file
- chore: bump to v2.5.3